### PR TITLE
Allow multiple periods in commit messages, but only one at the end

### DIFF
--- a/grumphp.dist.yml
+++ b/grumphp.dist.yml
@@ -46,7 +46,7 @@ parameters:
       max_body_width: 72
       max_subject_width: 60
       matchers:
-        Must match regex: /([A-Z]+-[\d]+ )+\| [A-Z\d]([^.])+\./s
+        Must match regex: /([A-Z]+-[\d]+ )+\| [A-Za-z\d\s\.]+([^.])+\.{1}$/s
       case_insensitive: false
       multiline: true
       additional_modifiers: ''


### PR DESCRIPTION
Test commit message that initially faulted:
`EL-717 | Update Drupal core 8.6.3 to 8.6.5 in Composer lockfile.`

![devtools-screenshot](https://user-images.githubusercontent.com/30412380/50650769-b26a0080-0f81-11e9-9136-2f1573d0f931.png)